### PR TITLE
Show progress whilst copying files to new disk

### DIFF
--- a/adafruit-pi-externalroot-helper
+++ b/adafruit-pi-externalroot-helper
@@ -127,7 +127,7 @@ info "fs copy" "Mounting ${target_partition} on /mnt"
 
 info "fs copy" "Copying root filesystem to ${target_partition} with rsync"
 info "fs copy" "This will take quite a while.  Please be patient!"
-    rsync -ax / /mnt
+    rsync -ax --info=progress2 / /mnt
 
 info "boot config" "Configuring boot from {$target_partition}"
     # rootdelay=5 is likely not necessary here, but seems to do no harm.


### PR DESCRIPTION
After completion you'll see something like this in the output:

    [fs copy] Mounting /dev/sda1 on /mnt
    [fs copy] Copying root filesystem to /dev/sda1 with rsync
    [fs copy] This will take quite a while.  Please be patient!
     15,446,610,948  99%   10.48MB/s    0:23:26 (xfr#128025, to-chk=0/189353)   
    [boot config] Configuring boot from {/dev/sda1}
    [boot config] Commenting out old root partition in /etc/fstab, adding new one

During the copy the numbers update so people can see that the file copy is actually active and get some idea of how long it'll take.

I don't know why the final progress shows as 99%. i guess that's an `rsync` bug but haven't looked into it.