### PR TITLE
Added a delay before mkfs command to fix error "The file /dev/sda1 do…

### DIFF
--- a/adafruit-pi-externalroot-helper
+++ b/adafruit-pi-externalroot-helper
@@ -104,6 +104,7 @@ info "fs create" "Creating ${target_partition}"
     parted --script --align optimal "${target_drive}" mkpart primary ext4 0% 100%
 
 info "fs create" "Creating ext4 filesystem on ${target_partition}"
+    sleep 5
     mkfs -t ext4 -L rootfs "${target_partition}"
 
 info "fs id" "Getting UUID for target partition"


### PR DESCRIPTION
`Sleep 5` before the `mkfs` command allows the script to run on my Pi 3. Previously failed with:

```
    [fs create] Creating /dev/sda1
    [fs create] Creating ext4 filesystem on /dev/sda1
    mke2fs 1.42.12 (29-Aug-2014)
    The file /dev/sda1 does not exist and no size was specified.
```

See [this issue](https://github.com/adafruit/Adafruit-Pi-ExternalRoot-Helper/issues/5) for details.

PS This is my first pull request for anything!!! :-D
